### PR TITLE
refactor : 로그인 회원가입 검증 코드 추가

### DIFF
--- a/src/main/java/com/hanwul/kbscbackend/config/CorsConfig.java
+++ b/src/main/java/com/hanwul/kbscbackend/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.hanwul.kbscbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true); // 내 서버가 응답을 할 때 Json을 자바스크립트에서 처리할 수 있게 할지를 설정하는 것
+//        config.addAllowedOrigin("*"); // 모든 ip에 응답을 허용
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*"); // 모든 header에 응답을 허용
+        config.addAllowedMethod("*"); // 모든 Method(post, get, put, delte) 에 응답을 허용
+        config.addExposedHeader("Authorization");
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/hanwul/kbscbackend/config/SecurityConfig.java
+++ b/src/main/java/com/hanwul/kbscbackend/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
 
 
 @Configuration
@@ -21,21 +24,25 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig{
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CorsFilter corsFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .addFilter(corsFilter)
                 .httpBasic().disable() // rest api -> 기본 설정 disable
                 .csrf().disable() // csrf -> 비활성화
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/user/log-in", "/user/sign-up").permitAll() // 가입, 로그인에 대한 권한 해제
+                .antMatchers("/api/v1/user/login", "/api/v1/user/sign-up").permitAll() // 가입, 로그인에 대한 권한 해제
+                .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/hanwul/kbscbackend/config/SecurityConfig.java
+++ b/src/main/java/com/hanwul/kbscbackend/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
-public class SecurityConfig{
+public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CorsFilter corsFilter;
@@ -41,7 +41,7 @@ public class SecurityConfig{
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/user/login", "/api/v1/user/sign-up").permitAll() // 가입, 로그인에 대한 권한 해제
+                .antMatchers("/api/v1/user/login", "/api/v1/user/sign-up", "/").permitAll() // 회원가입, 로그인, 메인페이지에 대한 권한 해제
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/Account.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/Account.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter @Setter
-@NoArgsConstructor
 @Table(name = "account")
 @Entity
 public class Account implements UserDetails {

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/Account.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/Account.java
@@ -24,17 +24,16 @@ import java.util.stream.Collectors;
 @Entity
 public class Account implements UserDetails {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 45)
+    @Column(length = 45, unique = true)
     private String username;
 
     private String password;
 
-    @Column(length = 45)
+    @Column(length = 45, unique = true)
     private String nickname;
 
     @OneToMany(mappedBy = "constructor", cascade = CascadeType.ALL)

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/AccountController.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/AccountController.java
@@ -17,16 +17,18 @@ import java.util.Map;
 public class AccountController {
     private final JwtTokenProvider jwtTokenProvider;
     private final AccountService accountService;
-    private final CustomUserDetailService customUserDetailService;
 
     @PostMapping("/sign-up")
-    public Account join(@Valid @RequestBody SignUpDto signUpDto){
+    public Account join(@Valid @RequestBody SignUpDto signUpDto) {
         return accountService.save(signUpDto);
     }
 
     @PostMapping("/login")
-    public String login(@Valid @RequestBody LoginDto loginDto){
-        Account account = accountService.load(loginDto);
-        return jwtTokenProvider.createToken(account.getUsername(), account.getRoles());
+    public String login(@Valid @RequestBody LoginDto loginDto) {
+        boolean authenciate = accountService.check(loginDto);
+        if (authenciate) {
+            return jwtTokenProvider.createToken(loginDto.getUsername(), loginDto.getRoles());
+        }
+        return "error";
     }
 }

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/AccountController.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/AccountController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -19,13 +20,13 @@ public class AccountController {
     private final CustomUserDetailService customUserDetailService;
 
     @PostMapping("/sign-up")
-    public Account join(@RequestBody SignUpDto signUpDto){
+    public Account join(@Valid @RequestBody SignUpDto signUpDto){
         return accountService.save(signUpDto);
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody Map<String, String> user){
-        Account account = (Account)customUserDetailService.loadUserByUsername(user.get("username"));
+    public String login(@Valid @RequestBody LoginDto loginDto){
+        Account account = accountService.load(loginDto);
         return jwtTokenProvider.createToken(account.getUsername(), account.getRoles());
     }
 }

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/AccountService.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/AccountService.java
@@ -1,8 +1,13 @@
 package com.hanwul.kbscbackend.domain.account;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -10,10 +15,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class AccountService {
 
     private final AccountRepository accountRepository;
+    private final PasswordEncoder passwordEncoder;
 
     //회원 가입
     public Account save(SignUpDto signUpDto){
-        return accountRepository.save(signUpDto.toEntity());
+        return accountRepository.save(toEntity(signUpDto));
+    }
+
+    //로그인
+    public Account load(LoginDto loginDto){
+        Account member = accountRepository.findByUsername(loginDto.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 E-MAIL 입니다."));
+        return member;
+    }
+
+    public Account toEntity(SignUpDto signUpDto){
+        return Account.builder()
+                .username(signUpDto.getUsername())
+                .password(passwordEncoder.encode(signUpDto.getPassword()))
+                .nickname(signUpDto.getNickname())
+                .build();
     }
 
 }

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/AccountService.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/AccountService.java
@@ -18,18 +18,23 @@ public class AccountService {
     private final PasswordEncoder passwordEncoder;
 
     //회원 가입
-    public Account save(SignUpDto signUpDto){
+    public Account save(SignUpDto signUpDto) {
         return accountRepository.save(toEntity(signUpDto));
     }
 
-    //로그인
-    public Account load(LoginDto loginDto){
+    // 로그인
+    public boolean check(LoginDto loginDto) {
+        // 입력받은 password
+        String password = loginDto.getPassword();
         Account member = accountRepository.findByUsername(loginDto.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 E-MAIL 입니다."));
-        return member;
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 Username 입니다."));
+        if (passwordEncoder.matches(password, member.getPassword())) {
+            return true;
+        }
+        return false;
     }
 
-    public Account toEntity(SignUpDto signUpDto){
+    public Account toEntity(SignUpDto signUpDto) {
         return Account.builder()
                 .username(signUpDto.getUsername())
                 .password(passwordEncoder.encode(signUpDto.getPassword()))

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/LoginDto.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/LoginDto.java
@@ -5,7 +5,11 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.ElementCollection;
+import javax.persistence.FetchType;
 import javax.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -16,8 +20,11 @@ public class LoginDto {
     @NotBlank
     private String password;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles = new ArrayList<>();
+
     @Builder
-    public LoginDto(String username, String password){
+    public LoginDto(String username, String password) {
         this.username = username;
         this.password = password;
     }

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/LoginDto.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/LoginDto.java
@@ -1,27 +1,24 @@
 package com.hanwul.kbscbackend.domain.account;
 
-
-
-import lombok.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 @Data
-public class SignUpDto {
+public class LoginDto {
     @NotBlank
     private String username;
     @NotBlank
     private String password;
-    @NotBlank
-    private String nickname;
 
     @Builder
-    public SignUpDto(String username, String password, String nickname){
+    public LoginDto(String username, String password){
         this.username = username;
         this.password = password;
-        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/hanwul/kbscbackend/domain/account/SignUpDto.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/account/SignUpDto.java
@@ -1,11 +1,11 @@
 package com.hanwul.kbscbackend.domain.account;
 
 
-
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor
@@ -14,12 +14,13 @@ public class SignUpDto {
     @NotBlank
     private String username;
     @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])((?=.*[~!@#$%^&*()_+=])|(?=.*\\d))[A-Za-z\\d~!@#$%^&*()_+=]{8,}$")
     private String password;
     @NotBlank
     private String nickname;
 
     @Builder
-    public SignUpDto(String username, String password, String nickname){
+    public SignUpDto(String username, String password, String nickname) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/hanwul/kbscbackend/domain/mission/MissionController.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/mission/MissionController.java
@@ -24,10 +24,6 @@ public class MissionController {
         return service.changeStatus(missionId);
     }
 
-//    @GetMapping
-//    public void getHistory(){
-//         history
-//    }
 
 
 }

--- a/src/main/java/com/hanwul/kbscbackend/domain/mission/MissionController.java
+++ b/src/main/java/com/hanwul/kbscbackend/domain/mission/MissionController.java
@@ -24,10 +24,10 @@ public class MissionController {
         return service.changeStatus(missionId);
     }
 
-    @GetMapping
-    public void getHistory(){
-        // history
-    }
+//    @GetMapping
+//    public void getHistory(){
+//         history
+//    }
 
 
 }


### PR DESCRIPTION
기존에 발생 했던 문제점
1. 같은 username과 nickname을 통해 회원가입을 해도 진행되었던 점
-> Account 엔티티에 unique를 활용해 해결했습니다.
2. 로그인 시 username만 일치하고 password가 틀려도 토큰이 발급된점
-> 분기문을 통해 error가 발생하도록 변경했습니다.
3. 비밀번호의 단순화
-> 정규식을 통해 비밀번호는 8자리 이상 숫자 및 특수문자 1개 이상 포함으로 변경했습니다.